### PR TITLE
Make keypresses not hijack the user's scroll

### DIFF
--- a/src/ReactTerminalStateless.js
+++ b/src/ReactTerminalStateless.js
@@ -18,6 +18,7 @@ class TerminalStateless extends Component {
     this.historyKeyboardPlugin = new HistoryKeyboardPlugin(emulatorState);
     this.plugins = [this.historyKeyboardPlugin];
     this.inputRef = null;
+    this.containerRef = null;
     this.dragStart = {};
     this.dragging = false;
   }
@@ -28,12 +29,14 @@ class TerminalStateless extends Component {
     }
   }
 
+  scrollOutput() {
+    this.containerRef.scrollTop = this.containerRef.scrollHeight;
+  }
+
   componentDidUpdate() {
     const {autoFocus} = this.props;
-
-    if (this.inputRef) {
-      this.inputRef.scrollIntoView();
-    }
+    
+    this.scrollOutput();
 
     if (autoFocus) {
       this.focus();
@@ -81,7 +84,7 @@ class TerminalStateless extends Component {
 
   _onClick = () => {
     if (this.inputRef && !this.dragging) {
-      this.inputRef.scrollIntoView();
+      this.scrollOutput();
       this.inputRef.focus();
     }
   };
@@ -140,6 +143,7 @@ class TerminalStateless extends Component {
       <ThemeProvider theme={theme}>
         <TerminalContainer
           className={'terminalContainer'}
+          ref={(ref) => { this.containerRef = ref; }}
           {...focusProps}
         >
           <OutputList

--- a/src/input/CommandInput.js
+++ b/src/input/CommandInput.js
@@ -9,10 +9,6 @@ class CommandInput extends Component {
     this.input.focus();
   }
 
-  scrollIntoView() {
-    this.input.scrollIntoView(false);
-  }
-
   render() {
     const { autoFocus, promptSymbol, value, onChange, onSubmit, onKeyDown } = this.props;
 


### PR DESCRIPTION
I have a page where the terminal is supposed to be centered at the top, but .scrollIntoView hijacks the whole page's scroll instead of just the terminal container (even when autoFocus is false!)

This is annoying because it centers the text field in the whole page, so the UI element below it gets scrolled out of view repeatedly.