### PR TITLE
Allow space before/after prompt symbol

### DIFF
--- a/src/PromptSymbol.js
+++ b/src/PromptSymbol.js
@@ -3,6 +3,7 @@ import defaultTheme from 'themes/default';
 
 const PromptSymbol = styled.span`
   margin-right: 0.25em;
+  white-space: pre;
   color: ${({ theme }) => theme.promptSymbolColor};
 `;
 


### PR DESCRIPTION
I wanted a bit more space after the 0.25em, this just allows prompt='> ' to work